### PR TITLE
move layer informations in asset

### DIFF
--- a/fio_stac/stac.py
+++ b/fio_stac/stac.py
@@ -248,8 +248,6 @@ def create_stac_item(
             schema = lyr_dst.schema
             layer_schemas.update({layer: schema})
 
-    properties.update({"vector:layers": layer_schemas})
-
     # item
     item = pystac.Item(
         id=item_id,
@@ -283,6 +281,7 @@ def create_stac_item(
                 href=asset_href or source,
                 media_type=media_type,
                 roles=asset_roles,
+                extra_fields={"vector:layers": layer_schemas},
             ),
         )
 


### PR DESCRIPTION
closes #3 

This PR propose to move the `layer` informations in the `Asset` block instead of properties!

This could also be an option 🤷‍♂️ 